### PR TITLE
fixed using single quotes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ exports.default = function (content) {
     try {
       var value = typeof content === 'string' ? JSON.parse(content) : content;
       value = JSON.stringify(value).replace(/\u2028/g, '\\u2028').replace(/\u2029/g, '\\u2029');
-      var code = 'module.exports = function (Component) { Component.options.__i18n = \'' + value + '\' }';
+      var code = 'module.exports = function (Component) { Component.options.__i18n = \'' + value.replace(/\u0027/g, '\\u0027') + '\' }';
       this.callback(null, code);
     } catch (err) {
       this.emitError(err.message);

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ export default function (content) {
       value = JSON.stringify(value)
         .replace(/\u2028/g, '\\u2028')
         .replace(/\u2029/g, '\\u2029')
-      const code = `module.exports = function (Component) { Component.options.__i18n = '${value}' }`
+      const code = `module.exports = function (Component) { Component.options.__i18n = '${value.replace(/\u0027/g, '\\u0027')}' }`
       this.callback(null, code)
     } catch (err) {
       this.emitError(err.message)


### PR DESCRIPTION
Fixed the possibility of using single quoted strings as text, like:

`{
	  "en": {
	    "title": "Hi, I'm {name}!"
	  }
}`