### PR TITLE
Vue-i18n -> VueI18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ import Vue from 'vue'
 import VueI18n from 'vue-i18n'
 import App from './App.vue'
 
-Vue.use(Vue-i18n)
+Vue.use(VueI18n)
 
 const i18n = new VueI18n({
   locale: 'en',


### PR DESCRIPTION
`Vue-i18n` is not a valid identifier name.