### PR TITLE
Add support for webpack without vue-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ new Vue({
 
 ### Webpack Config 
 
-`vue-loader` (v15 later):
+`vue-loader` (v15 or later):
 
 ```javascript
 // for vue.config.js (Vue CLI)
@@ -85,6 +85,22 @@ module.exports = {
       .type('javascript/auto')
       .use('i18n')
       .loader('@kazupon/vue-i18n-loader')
+  }
+}
+```
+
+`vue-loader` (v15 or later):
+
+```javascript
+// for webpack.config.js (Without Vue CLI)
+module.exports = {
+  module: {
+    rules: [
+      {
+        resourceQuery: /blockType=i18n/,
+        loader: '@kazupon/vue-i18n-loader',
+      },
+    ]
   }
 }
 ```


### PR DESCRIPTION
I don't use Vue CLI, and I had to dig around a bit to find out how to use this.
I recommend adding this to the readme, so users without vue-cli can also know how to use it.